### PR TITLE
Ensure the Template Enhancement Output Buffer is started for Markdown responses

### DIFF
--- a/html-to-md.php
+++ b/html-to-md.php
@@ -5,6 +5,7 @@
  * Author: Dennis Snell <dennis.snell@automattic.com>
  * Description: Convert HTML documents to Markdown using WordPress’ HTML API.
  * Version: 2026-02-01
+ * Requires at least: 6.9
  */
 
 // Don’t load directly.

--- a/html-to-md.php
+++ b/html-to-md.php
@@ -31,17 +31,26 @@ add_filter( 'html_to_markdown_starting_node_finder', fn ( $prev ) =>
 	return false;
 } );
 
-remove_all_filters( 'wp_template_enhancement_output_buffer' );
-add_filter( 'wp_template_enhancement_output_buffer', function ( $output, $original ) {
+add_action( 'init', function () {
 	$has_accept_header = isset( $_SERVER['HTTP_ACCEPT'] );
 	$has_markdown_type = $has_accept_header && 1 === preg_match( '~^text/markdown(?:;|$)~', $_SERVER['HTTP_ACCEPT'] );
 	$has_markdown_query_arg = in_array( $_GET['output_format'] ?? '', array( 'md', 'markdown' ), true );
 
 	if ( ! ( $has_markdown_type || $has_markdown_query_arg ) ) {
-		return  $output;
+		return;
 	}
 
-	header( 'Content-type: text/markdown; charset=utf-8' );
+	// Force the template enhancement output buffer to always be enabled for markdown responses.
+	add_filter( 'wp_should_output_buffer_template_for_enhancement', '__return_true', PHP_INT_MAX );
 
-	return html_to_md( $output );
-}, 1000, 2 );
+	remove_all_filters( 'wp_template_enhancement_output_buffer' );
+
+	add_filter(
+		'wp_template_enhancement_output_buffer',
+		function ( $output ) {
+			header( 'Content-type: text/markdown; charset=utf-8' );
+			return html_to_md( $output );
+		},
+		1000
+	);
+} );

--- a/html-to-md.php
+++ b/html-to-md.php
@@ -53,4 +53,15 @@ add_action( 'init', function () {
 		},
 		1000
 	);
+
+	// Add a sanity check for whether the output buffer did indeed start.
+	add_action(
+		'wp_before_include_template',
+		function () {
+			if ( ! did_action( 'wp_template_enhancement_output_buffer_started' ) ) {
+				wp_die( 'Markdown is not available.', 406 );
+			}
+		},
+		PHP_INT_MAX
+	);
 } );


### PR DESCRIPTION
1. Ensure that WordPress 6.9 is the minimum version, since this is when the the template enhancement output buffer was introduced.
2. Add a `wp_should_output_buffer_template_for_enhancement` filter to force the output buffer to get added when Markdown is being requested.
3. Respond with `406 Not Acceptable` if the template enhancement buffer still wasn't started (perhaps by the action being unhooked);

<img width="806" height="139" alt="image" src="https://github.com/user-attachments/assets/7d894b6b-002a-42f4-a45a-7019009348c2" />
