### PR TITLE
Assert that formats are only released when they are open.

### DIFF
--- a/lib/class-wp-experimental-html-renderer-line-buffer.php
+++ b/lib/class-wp-experimental-html-renderer-line-buffer.php
@@ -76,7 +76,7 @@ class WP_Experimental_HTML_Renderer_Line_Buffer {
 		 * Sometimes, the line buffer has been replaced by the time that the
 		 * format is released. What could cause this to happen?
 		 */
-//		assert( count( $this->open_formats ) > 0 );
+		assert( count( $this->open_formats ) > 0 );
 		$this->format_indices[] = \array_pop( $this->open_formats );
 	}
 

--- a/tests/RegressionsTest.php
+++ b/tests/RegressionsTest.php
@@ -1,0 +1,35 @@
+<?php
+
+use PHPUnit\Framework\Attributes\DataProvider;
+
+class RegressionsTest extends PHPUnit\Framework\TestCase {
+	/**
+	 * Verifies that the parser does not break known invariants.
+	 *
+	 * Invariants include things like:
+	 *
+	 *  - Closing a format when it’s not open.
+	 *  - Exiting a block that isn’t open.
+	 *
+	 * @ticket {TICKET_NUMBER}
+	 *
+	 * @param string $html Contains conditions known to have broken the invariants.
+	 * @return void
+	 */
+	#[DataProvider( 'data_assertion_tests' )]
+	public function test_invariant_breakers( string $html ): void {
+		// If the assert() fails, the test will too.
+		wp_html_to_markdown( $html );
+	}
+
+	/**
+	 * Data provider.
+	 *
+	 * @return array[]
+	 */
+	public static function data_assertion_tests(): array {
+		return array(
+			'Link surrounding ATX header, which opens a block.' => array( '<a><h1>' ),
+		);
+	}
+}


### PR DESCRIPTION
This is happening because some HTML tags, like the H1–H6 tags, open a new block context and create a new line buffer. If the `A` tag surrounds the ATX heading element, then it gets lost.

What is probably the cause is that we’re eagerly discarding line buffers. In the minimized test case, we should probably be accumulating formats in the line buffer while no text exists, and then keep that line buffer when entering the new block.

This _should_ work with the way that block flushing occurs because the line buffer will associate with the ATX block and formats will be applied before the block word-wraps and adds the header prefix.