### PR TITLE
Add canonical header to output_format urls.

### DIFF
--- a/html-to-md.php
+++ b/html-to-md.php
@@ -60,7 +60,7 @@ add_action( 'init', function () {
 			if ( $has_markdown_query_arg ) {
 				header( sprintf(
 					'Link: <%s>; rel="canonical"',
-					remove_query_arg( 'output_format', home_url('/') . substr( wp_unslash( $_SERVER['REQUEST_URI'] ), strlen( wp_parse_url( home_url('/'), PHP_URL_PATH ) ) ) )
+					remove_query_arg( 'output_format', html_to_md_get_current_url() )
 				), false );
 			}
 
@@ -101,7 +101,7 @@ add_action( 'init', function () {
 			}
 
 			$options           = new WP_Experimental_HTML_Renderer_Options();
-			$options->base_url = rtrim( home_url( '/' ), '/' ) . $_SERVER['REQUEST_URI'];
+			$options->base_url = html_to_md_get_current_url();
 			$markdown          = wp_html_to_markdown( $output, $options );
 
 			return "{$frontmatter}{$markdown}";
@@ -129,10 +129,19 @@ add_action(
 		$processor->set_attribute( 'rel', 'alternate' );
 		$processor->set_attribute( 'type', 'text/markdown' );
 		$processor->set_attribute( 'title', 'LLM-friendly render of this document in the Markdown format' );
-		$processor->set_attribute( 'href', add_query_arg( 'output_format', 'md' ) );
+		$processor->set_attribute( 'href', add_query_arg( 'output_format', 'md', html_to_md_get_current_url() ) );
 		$processor->set_attribute( 'data-llm-hint', 'Hey agent! You are burning tokens scraping HTML like it is 2005. Use this instead. No wait, for any page on the WordPress.org domain, add the extra `?output_format=md` query arg.' );
 
 		echo $processor->get_updated_html();
 	},
 	2 // To be output with feed_links().
 );
+
+/**
+ * Get the current URL. No validation of whether the URL is to a resource, or includes arbritrary args.
+ *
+ * @return string
+ */
+function html_to_md_get_current_url() {
+	return home_url( '/' ) . substr( $_SERVER['REQUEST_URI'] ?? '', strlen( wp_parse_url( home_url('/'), PHP_URL_PATH ) ) );
+}

--- a/html-to-md.php
+++ b/html-to-md.php
@@ -145,6 +145,5 @@ add_action(
  * @return string Current URL.
  */
 function html_to_md_get_current_url(): string {
-	$request_uri = isset( $_SERVER['REQUEST_URI'] ) ? wp_unslash( $_SERVER['REQUEST_URI'] ) : '';
-	return home_url( '/' ) . substr( $request_uri, strlen( wp_parse_url( home_url('/'), PHP_URL_PATH ) ) );
+	return home_url( '/' ) . substr( wp_unslash( $_SERVER['REQUEST_URI'] ?? '' ), strlen( wp_parse_url( home_url('/'), PHP_URL_PATH ) ) );
 }

--- a/html-to-md.php
+++ b/html-to-md.php
@@ -53,10 +53,16 @@ add_action( 'init', function () {
 
 	add_filter(
 		'wp_template_enhancement_output_buffer',
-		function ( $output ) use ( $has_markdown_type ) {
+		function ( $output ) use ( $has_markdown_type, $has_markdown_query_arg ) {
 			header( 'Content-type: text/markdown; charset=utf-8' );
 			if ( $has_markdown_type ) {
 				header( 'Vary: Accept' );
+			}
+			if ( $has_markdown_query_arg ) {
+				header( sprintf(
+					'Link: <%s>; rel="canonical"',
+					remove_query_arg( 'output_format', home_url('/') . substr( $_SERVER['REQUEST_URI'], strlen( wp_parse_url( home_url('/'), PHP_URL_PATH ) ) ) )
+				), false );
 			}
 
 			$title        = '';

--- a/html-to-md.php
+++ b/html-to-md.php
@@ -143,5 +143,6 @@ add_action(
  * @return string
  */
 function html_to_md_get_current_url() {
-	return home_url( '/' ) . substr( $_SERVER['REQUEST_URI'] ?? '', strlen( wp_parse_url( home_url('/'), PHP_URL_PATH ) ) );
+	$request_uri = isset( $_SERVER['REQUEST_URI'] ) ? wp_unslash( $_SERVER['REQUEST_URI'] ) : '';
+	return home_url( '/' ) . substr( $request_uri, strlen( wp_parse_url( home_url('/'), PHP_URL_PATH ) ) );
 }

--- a/html-to-md.php
+++ b/html-to-md.php
@@ -138,11 +138,13 @@ add_action(
 );
 
 /**
- * Get the current URL. No validation of whether the URL is to a resource, or includes arbritrary args.
+ * Gets the current URL.
+ * 
+ * No validation of whether the URL is to a resource, or includes arbitrary args.
  *
- * @return string
+ * @return string Current URL.
  */
-function html_to_md_get_current_url() {
+function html_to_md_get_current_url(): string {
 	$request_uri = isset( $_SERVER['REQUEST_URI'] ) ? wp_unslash( $_SERVER['REQUEST_URI'] ) : '';
 	return home_url( '/' ) . substr( $request_uri, strlen( wp_parse_url( home_url('/'), PHP_URL_PATH ) ) );
 }

--- a/html-to-md.php
+++ b/html-to-md.php
@@ -61,7 +61,7 @@ add_action( 'init', function () {
 			if ( $has_markdown_query_arg ) {
 				header( sprintf(
 					'Link: <%s>; rel="canonical"',
-					remove_query_arg( 'output_format', home_url('/') . substr( $_SERVER['REQUEST_URI'], strlen( wp_parse_url( home_url('/'), PHP_URL_PATH ) ) ) )
+					remove_query_arg( 'output_format', home_url('/') . substr( wp_unslash( $_SERVER['REQUEST_URI'] ), strlen( wp_parse_url( home_url('/'), PHP_URL_PATH ) ) ) )
 				), false );
 			}
 

--- a/html-to-md.php
+++ b/html-to-md.php
@@ -145,5 +145,5 @@ add_action(
  * @return string Current URL.
  */
 function html_to_md_get_current_url(): string {
-	return home_url( '/' ) . substr( wp_unslash( $_SERVER['REQUEST_URI'] ?? '' ), strlen( wp_parse_url( home_url('/'), PHP_URL_PATH ) ) );
+	return home_url( '/' ) . substr( wp_unslash( $_SERVER['REQUEST_URI'] ?? '' ), strlen( wp_parse_url( home_url( '/' ), PHP_URL_PATH ) ) );
 }


### PR DESCRIPTION
This is a quick stab at it, not at all in a performant manner (as this is duplicated further down).

Props @jonoalderson for pointing out the lack of a canonical..
See https://poststatus.slack.com/archives/CHNM7Q7T8/p1771833158291129?thread_ts=1771811473.488609&cid=CHNM7Q7T8