### PR TITLE
Fix regex for markdown content type detection

### DIFF
--- a/html-to-md.php
+++ b/html-to-md.php
@@ -38,8 +38,7 @@ add_filter( 'html_to_markdown_starting_node_finder', fn ( $prev ) =>
 } );
 
 add_action( 'init', function () {
-	$has_accept_header = isset( $_SERVER['HTTP_ACCEPT'] );
-	$has_markdown_type = $has_accept_header && 1 === preg_match( '~^text/(?:x-)?markdown(?:,|;|$)~', $_SERVER['HTTP_ACCEPT'] );
+	$has_markdown_type = 1 === preg_match( '~^text/(?:x-)?markdown(?:,|;|$)~', $_SERVER['HTTP_ACCEPT'] ?? '' );
 	$has_markdown_query_arg = in_array( $_GET['output_format'] ?? '', array( 'md', 'markdown' ), true );
 
 	if ( ! ( $has_markdown_type || $has_markdown_query_arg ) ) {

--- a/html-to-md.php
+++ b/html-to-md.php
@@ -39,7 +39,7 @@ add_filter( 'html_to_markdown_starting_node_finder', fn ( $prev ) =>
 
 add_action( 'init', function () {
 	$has_accept_header = isset( $_SERVER['HTTP_ACCEPT'] );
-	$has_markdown_type = $has_accept_header && 1 === preg_match( '~^text/(?:x-)?markdown(?:;|$)~', $_SERVER['HTTP_ACCEPT'] );
+	$has_markdown_type = $has_accept_header && 1 === preg_match( '~^text/(?:x-)?markdown(?:,;|$)~', $_SERVER['HTTP_ACCEPT'] );
 	$has_markdown_query_arg = in_array( $_GET['output_format'] ?? '', array( 'md', 'markdown' ), true );
 
 	if ( ! ( $has_markdown_type || $has_markdown_query_arg ) ) {

--- a/html-to-md.php
+++ b/html-to-md.php
@@ -39,7 +39,7 @@ add_filter( 'html_to_markdown_starting_node_finder', fn ( $prev ) =>
 
 add_action( 'init', function () {
 	$has_accept_header = isset( $_SERVER['HTTP_ACCEPT'] );
-	$has_markdown_type = $has_accept_header && 1 === preg_match( '~^text/(?:x-)?markdown(?:,;|$)~', $_SERVER['HTTP_ACCEPT'] );
+	$has_markdown_type = $has_accept_header && 1 === preg_match( '~^text/(?:x-)?markdown(?:,|;|$)~', $_SERVER['HTTP_ACCEPT'] );
 	$has_markdown_query_arg = in_array( $_GET['output_format'] ?? '', array( 'md', 'markdown' ), true );
 
 	if ( ! ( $has_markdown_type || $has_markdown_query_arg ) ) {


### PR DESCRIPTION
The regular expression doesn't support the most common accept header format used by those that support markdown: `text/markdown, text/html, */*`.

These two commands should return the same content:
1. `curl -H 'Accept: text/markdown, text/html, */*' https://example.org`
2. `curl -H 'Accept: text/markdown' https://example.org`