### PR TITLE
Allow filtering frontmatter fields and emit proper YAML

### DIFF
--- a/html-to-md.php
+++ b/html-to-md.php
@@ -12,6 +12,7 @@
  */
 
 use WordPress\Experiments\HtmlToMarkdown\WP_Experimental_HTML_Renderer_Options;
+use function WordPress\Experiments\HtmlToMarkdown\render_yaml;
 
 // Don’t load directly.
 if ( ! defined( 'ABSPATH' ) ) {
@@ -20,6 +21,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 require_once __DIR__ . '/wp-experimental-html-renderer-loader.php';
 require_once __DIR__ . '/wp-html-to-markdown.php';
+require_once __DIR__ . '/wp-yaml-emitter.php';
 
 add_filter( 'html_to_markdown_starting_node_finder', fn ( $prev ) =>
 	$prev ?? function ( $p ) {
@@ -96,8 +98,8 @@ add_action( 'init', function () {
 			 */
 			$fields = (array) apply_filters( 'html_to_markdown_frontmatter_fields', $fields, $post );
 
-			$frontmatter_body = wp_html_to_markdown_render_yaml( $fields );
-			$frontmatter     = '' === $frontmatter_body
+			$frontmatter_body = render_yaml( $fields );
+			$frontmatter      = '' === $frontmatter_body
 				? ''
 				: "---\n{$frontmatter_body}---\n\n";
 
@@ -137,102 +139,3 @@ add_action(
 	},
 	2 // To be output with feed_links().
 );
-
-/**
- * Renders a PHP array as a YAML mapping or sequence body.
- *
- * Accepts string, int, float, bool, null, and nested arrays. Empty strings and
- * arrays whose contents all filter out are dropped. Unsupported leaf types
- * (objects, resources, etc.) trigger _doing_it_wrong() and are skipped.
- *
- * Output is the inner body only — callers wrap it in `---` document markers
- * if they need a frontmatter block.
- */
-function wp_html_to_markdown_render_yaml( array $value, int $indent = 0 ): string {
-	$pad     = str_repeat( '  ', $indent );
-	$is_list = array_is_list( $value );
-	$out     = '';
-
-	foreach ( $value as $key => $v ) {
-		if ( is_array( $v ) ) {
-			$rendered = wp_html_to_markdown_render_yaml( $v, $indent + 1 );
-			if ( '' === $rendered ) {
-				continue;
-			}
-		} elseif ( wp_html_to_markdown_is_yaml_scalar( $v ) ) {
-			if ( is_string( $v ) && '' === $v ) {
-				continue;
-			}
-			$rendered = wp_html_to_markdown_render_yaml_scalar( $v );
-		} else {
-			_doing_it_wrong(
-				'apply_filters( "html_to_markdown_frontmatter_fields" )',
-				sprintf( 'Unsupported value type in YAML frontmatter: %s', esc_html( gettype( $v ) ) ),
-				'2026.02.18'
-			);
-			continue;
-		}
-
-		if ( $is_list ) {
-			$out .= is_array( $v )
-				? "{$pad}-\n{$rendered}"
-				: "{$pad}- {$rendered}\n";
-		} else {
-			$key_str = wp_html_to_markdown_render_yaml_key( (string) $key );
-			$out    .= is_array( $v )
-				? "{$pad}{$key_str}:\n{$rendered}"
-				: "{$pad}{$key_str}: {$rendered}\n";
-		}
-	}
-
-	return $out;
-}
-
-function wp_html_to_markdown_is_yaml_scalar( $v ): bool {
-	return is_string( $v ) || is_int( $v ) || is_float( $v ) || is_bool( $v ) || null === $v;
-}
-
-function wp_html_to_markdown_render_yaml_scalar( $v ): string {
-	if ( is_string( $v ) ) {
-		$escaped = str_replace( array( '\\', '"' ), array( '\\\\', '\\"' ), $v );
-		$escaped = str_replace( array( "\r\n", "\r", "\n" ), ' ', $escaped );
-		return "\"{$escaped}\"";
-	}
-	if ( is_bool( $v ) ) {
-		return $v ? 'true' : 'false';
-	}
-	if ( null === $v ) {
-		return 'null';
-	}
-	if ( is_float( $v ) ) {
-		if ( is_nan( $v ) ) {
-			return '.nan';
-		}
-		if ( is_infinite( $v ) ) {
-			return $v > 0 ? '.inf' : '-.inf';
-		}
-	}
-	return (string) $v;
-}
-
-function wp_html_to_markdown_render_yaml_key( string $key ): string {
-	// Quote when the key would otherwise be misparsed: empty, leading indicator
-	// character, embedded `: ` or `# `, trailing whitespace, numeric-looking, or
-	// matching a YAML 1.1 boolean/null literal.
-	$needs_quoting = (
-		'' === $key
-		|| 1 === preg_match( '/^[\s\-?:,\[\]\{\}#&*!|>\'"%@`]/', $key )
-		|| 1 === preg_match( '/[:#]\s/', $key )
-		|| 1 === preg_match( '/\s$/', $key )
-		|| is_numeric( $key )
-		|| in_array( strtolower( $key ), array( 'true', 'false', 'null', 'yes', 'no', 'on', 'off', '~' ), true )
-	);
-
-	if ( ! $needs_quoting ) {
-		return $key;
-	}
-
-	$escaped = str_replace( array( '\\', '"' ), array( '\\\\', '\\"' ), $key );
-	$escaped = str_replace( array( "\r\n", "\r", "\n" ), ' ', $escaped );
-	return "\"{$escaped}\"";
-}

--- a/html-to-md.php
+++ b/html-to-md.php
@@ -58,41 +58,48 @@ add_action( 'init', function () {
 				header( 'Vary: Accept' );
 			}
 
-			$title        = '';
-			$author       = '';
-			$published_on = '';
-			$modified_on  = '';
-			if ( is_singular() ) {
-				$title        = get_the_title();
-				$published_on = get_the_date();
-				$modified_on  = get_the_modified_date();
+			$post   = is_singular() ? get_post() : null;
+			$fields = array();
 
-				if ( post_type_supports( get_post()->post_type ?? '', 'author' ) ) {
-					$author = get_the_author_meta( 'display_name' );
+			if ( $post ) {
+				$fields['title']         = get_the_title();
+				$fields['published']     = get_the_date( 'Y-m-d' );
+				$fields['last_modified'] = get_the_modified_date( 'Y-m-d' );
+
+				if ( post_type_supports( $post->post_type, 'author' ) ) {
+					$fields['author'] = get_the_author_meta( 'display_name' );
+				}
+
+				if ( $fields['last_modified'] === $fields['published'] ) {
+					unset( $fields['last_modified'] );
 				}
 			} else {
 				$title_finder = new WP_HTML_Tag_Processor( $output );
 				if ( $title_finder->next_tag( 'title' ) ) {
-					$title = $title_finder->get_modifiable_text();
+					$fields['title'] = $title_finder->get_modifiable_text();
 				}
 			}
 
-			$frontmatter = '';
-			if ( ! empty( $title ) ) {
-				$frontmatter .= "Title: {$title}\n";
-			}
-			if ( ! empty( $author ) ) {
-				$frontmatter .= "Author: {$author}\n";
-			}
-			if ( ! empty( $published_on ) ) {
-				$frontmatter .= "Published: {$published_on}\n";
-			}
-			if ( ! empty( $modified_on ) && $modified_on !== $published_on ) {
-				$frontmatter .= "Last modified: {$modified_on}\n";
-			}
-			if ( ! empty( $frontmatter ) ) {
-				$frontmatter .= "\n---\n\n";
-			}
+			// Drop the plugin's empty defaults so consumers see only fields with values.
+			$fields = array_filter( $fields, static fn ( $v ) => '' !== $v );
+
+			/**
+			 * Filters the YAML frontmatter fields emitted before the markdown body.
+			 *
+			 * Keys become YAML keys. Values may be strings, ints, floats, bools, null,
+			 * or nested arrays (which render as block sequences/mappings). Empty
+			 * strings and arrays whose contents all drop out are omitted. Return an
+			 * empty array to suppress the frontmatter block entirely.
+			 *
+			 * @param array        $fields Associative array of YAML key => value.
+			 * @param WP_Post|null $post   Current post on singular requests, otherwise null.
+			 */
+			$fields = (array) apply_filters( 'html_to_markdown_frontmatter_fields', $fields, $post );
+
+			$frontmatter_body = wp_html_to_markdown_render_yaml( $fields );
+			$frontmatter     = '' === $frontmatter_body
+				? ''
+				: "---\n{$frontmatter_body}---\n\n";
 
 			$options           = new WP_Experimental_HTML_Renderer_Options();
 			$options->base_url = rtrim( home_url( '/' ), '/' ) . $_SERVER['REQUEST_URI'];
@@ -130,3 +137,102 @@ add_action(
 	},
 	2 // To be output with feed_links().
 );
+
+/**
+ * Renders a PHP array as a YAML mapping or sequence body.
+ *
+ * Accepts string, int, float, bool, null, and nested arrays. Empty strings and
+ * arrays whose contents all filter out are dropped. Unsupported leaf types
+ * (objects, resources, etc.) trigger _doing_it_wrong() and are skipped.
+ *
+ * Output is the inner body only — callers wrap it in `---` document markers
+ * if they need a frontmatter block.
+ */
+function wp_html_to_markdown_render_yaml( array $value, int $indent = 0 ): string {
+	$pad     = str_repeat( '  ', $indent );
+	$is_list = array_is_list( $value );
+	$out     = '';
+
+	foreach ( $value as $key => $v ) {
+		if ( is_array( $v ) ) {
+			$rendered = wp_html_to_markdown_render_yaml( $v, $indent + 1 );
+			if ( '' === $rendered ) {
+				continue;
+			}
+		} elseif ( wp_html_to_markdown_is_yaml_scalar( $v ) ) {
+			if ( is_string( $v ) && '' === $v ) {
+				continue;
+			}
+			$rendered = wp_html_to_markdown_render_yaml_scalar( $v );
+		} else {
+			_doing_it_wrong(
+				'apply_filters( "html_to_markdown_frontmatter_fields" )',
+				sprintf( 'Unsupported value type in YAML frontmatter: %s', esc_html( gettype( $v ) ) ),
+				'2026.02.18'
+			);
+			continue;
+		}
+
+		if ( $is_list ) {
+			$out .= is_array( $v )
+				? "{$pad}-\n{$rendered}"
+				: "{$pad}- {$rendered}\n";
+		} else {
+			$key_str = wp_html_to_markdown_render_yaml_key( (string) $key );
+			$out    .= is_array( $v )
+				? "{$pad}{$key_str}:\n{$rendered}"
+				: "{$pad}{$key_str}: {$rendered}\n";
+		}
+	}
+
+	return $out;
+}
+
+function wp_html_to_markdown_is_yaml_scalar( $v ): bool {
+	return is_string( $v ) || is_int( $v ) || is_float( $v ) || is_bool( $v ) || null === $v;
+}
+
+function wp_html_to_markdown_render_yaml_scalar( $v ): string {
+	if ( is_string( $v ) ) {
+		$escaped = str_replace( array( '\\', '"' ), array( '\\\\', '\\"' ), $v );
+		$escaped = str_replace( array( "\r\n", "\r", "\n" ), ' ', $escaped );
+		return "\"{$escaped}\"";
+	}
+	if ( is_bool( $v ) ) {
+		return $v ? 'true' : 'false';
+	}
+	if ( null === $v ) {
+		return 'null';
+	}
+	if ( is_float( $v ) ) {
+		if ( is_nan( $v ) ) {
+			return '.nan';
+		}
+		if ( is_infinite( $v ) ) {
+			return $v > 0 ? '.inf' : '-.inf';
+		}
+	}
+	return (string) $v;
+}
+
+function wp_html_to_markdown_render_yaml_key( string $key ): string {
+	// Quote when the key would otherwise be misparsed: empty, leading indicator
+	// character, embedded `: ` or `# `, trailing whitespace, numeric-looking, or
+	// matching a YAML 1.1 boolean/null literal.
+	$needs_quoting = (
+		'' === $key
+		|| 1 === preg_match( '/^[\s\-?:,\[\]\{\}#&*!|>\'"%@`]/', $key )
+		|| 1 === preg_match( '/[:#]\s/', $key )
+		|| 1 === preg_match( '/\s$/', $key )
+		|| is_numeric( $key )
+		|| in_array( strtolower( $key ), array( 'true', 'false', 'null', 'yes', 'no', 'on', 'off', '~' ), true )
+	);
+
+	if ( ! $needs_quoting ) {
+		return $key;
+	}
+
+	$escaped = str_replace( array( '\\', '"' ), array( '\\\\', '\\"' ), $key );
+	$escaped = str_replace( array( "\r\n", "\r", "\n" ), ' ', $escaped );
+	return "\"{$escaped}\"";
+}

--- a/wp-yaml-emitter.php
+++ b/wp-yaml-emitter.php
@@ -1,0 +1,102 @@
+<?php
+
+namespace WordPress\Experiments\HtmlToMarkdown;
+
+/**
+ * Renders a PHP array as a YAML mapping or sequence body.
+ *
+ * Accepts string, int, float, bool, null, and nested arrays. Empty strings and
+ * arrays whose contents all filter out are dropped. Unsupported leaf types
+ * (objects, resources, etc.) trigger _doing_it_wrong() and are skipped.
+ *
+ * Output is the inner body only — callers wrap it in `---` document markers
+ * if they need a frontmatter block.
+ */
+function render_yaml( array $value, int $indent = 0 ): string {
+	$pad     = str_repeat( '  ', $indent );
+	$is_list = array_is_list( $value );
+	$out     = '';
+
+	foreach ( $value as $key => $v ) {
+		if ( is_array( $v ) ) {
+			$rendered = render_yaml( $v, $indent + 1 );
+			if ( '' === $rendered ) {
+				continue;
+			}
+		} elseif ( is_yaml_scalar( $v ) ) {
+			if ( is_string( $v ) && '' === $v ) {
+				continue;
+			}
+			$rendered = render_yaml_scalar( $v );
+		} else {
+			_doing_it_wrong(
+				__NAMESPACE__ . '\\render_yaml',
+				sprintf( 'Unsupported value type in YAML output: %s', esc_html( gettype( $v ) ) ),
+				'2026.02.18'
+			);
+			continue;
+		}
+
+		if ( $is_list ) {
+			$out .= is_array( $v )
+				? "{$pad}-\n{$rendered}"
+				: "{$pad}- {$rendered}\n";
+		} else {
+			$key_str = render_yaml_key( (string) $key );
+			$out    .= is_array( $v )
+				? "{$pad}{$key_str}:\n{$rendered}"
+				: "{$pad}{$key_str}: {$rendered}\n";
+		}
+	}
+
+	return $out;
+}
+
+function is_yaml_scalar( $v ): bool {
+	return is_string( $v ) || is_int( $v ) || is_float( $v ) || is_bool( $v ) || null === $v;
+}
+
+function render_yaml_scalar( $v ): string {
+	if ( is_string( $v ) ) {
+		$escaped = str_replace( array( '\\', '"' ), array( '\\\\', '\\"' ), $v );
+		$escaped = str_replace( array( "\r\n", "\r", "\n" ), ' ', $escaped );
+		return "\"{$escaped}\"";
+	}
+	if ( is_bool( $v ) ) {
+		return $v ? 'true' : 'false';
+	}
+	if ( null === $v ) {
+		return 'null';
+	}
+	if ( is_float( $v ) ) {
+		if ( is_nan( $v ) ) {
+			return '.nan';
+		}
+		if ( is_infinite( $v ) ) {
+			return $v > 0 ? '.inf' : '-.inf';
+		}
+	}
+	return (string) $v;
+}
+
+function render_yaml_key( string $key ): string {
+	// Quote when the key would otherwise be misparsed: empty, leading indicator
+	// character, embedded `: ` or `# `, trailing whitespace, numeric-looking, or
+	// matching a YAML 1.1 boolean/null literal.
+	$needs_quoting = (
+		'' === $key
+		|| 1 === preg_match( '/^[\s\-?:,\[\]\{\}#&*!|>\'"%@`]/', $key )
+		|| 1 === preg_match( '/[:#]\s/', $key )
+		|| 1 === preg_match( '/\s$/', $key )
+		|| is_numeric( $key )
+		|| in_array( strtolower( $key ), array( 'true', 'false', 'null', 'yes', 'no', 'on', 'off', '~' ), true )
+	);
+
+	if ( ! $needs_quoting ) {
+		return $key;
+	}
+
+	$escaped = str_replace( array( '\\', '"' ), array( '\\\\', '\\"' ), $key );
+	$escaped = str_replace( array( "\r\n", "\r", "\n" ), ' ', $escaped );
+	return "\"{$escaped}\"";
+}


### PR DESCRIPTION
## Summary

Adds the `html_to_markdown_frontmatter_fields` filter so consumers can add, remove, or rewrite the frontmatter fields emitted before the markdown body, and switches the emitted block from informal labeled lines to standard YAML frontmatter.

I'm working on optimizing some [developer](https://developer.wordpress.org/) pages. We could add some structured content (such as `since_wp_version`) for some functions/filters.

### Filter

```php
add_filter( 'html_to_markdown_frontmatter_fields', function ( array $fields, ?WP_Post $post ) {
    if ( $post && has_term( '', 'post_tag', $post ) ) {
        $fields['tags'] = wp_get_post_tags( $post->ID, [ 'fields' => 'names' ] );
    }
    unset( $fields['author'] );
    return $fields;
}, 10, 2 );
```

The filter receives an associative array (keys become YAML keys, values are the scalars/structures) plus the current `WP_Post` (or `null` on archives).

### Output format

Before:
```
Title: Hello world
Author: Jake
Published: May 15, 2026

---
```

After:
```
---
title: "Hello world"
author: "Jake"
published: "2026-05-15"
---
```

- Standard YAML frontmatter wrapped in opening and closing `---` markers.
- ISO 8601 date-only (`YYYY-MM-DD`) for `published` and `last_modified` — easier for downstream tooling to parse than locale-formatted dates.
- Lowercase `snake_case` keys (`title`, `author`, `published`, `last_modified`).
- Values double-quoted with `\` and `"` escaped, embedded newlines collapsed to spaces.

### YAML emitter

A small recursive `render_yaml()` helper lives in a new `wp-yaml-emitter.php` at the repo root, namespaced under `WordPress\Experiments\HtmlToMarkdown`. Supports:

| PHP type | YAML output |
|---|---|
| `string` | `"escaped scalar"` |
| `int`, `float` | unquoted scalar (`5`, `3.14`); `.nan` / `.inf` for special floats |
| `bool` | `true` / `false` |
| `null` | `null` |
| indexed array | block sequence (`- item` per line) |
| associative array | nested block mapping with `+2` indent |
| anything else | `_doing_it_wrong()` notice; value skipped |

Map keys are auto-quoted when they contain risky characters (leading indicators, embedded `: `, boolean/null literals, numeric-looking strings, etc.). Empty strings and arrays whose contents all drop out are omitted, so consumers can suppress fields by setting them to `''` or `null`.

### Tested

Sandbox-tested on `developer.wordpress.org` (e.g. `/reference/functions/add_role/?output_format=md`).

## Test plan

- [ ] Hit a singular post with `?output_format=md` and verify the frontmatter renders as a valid YAML block bounded by `---`.
- [ ] Hit an archive/home and verify the `<title>`-derived fallback still appears (just `title:`).
- [ ] Hit a post on a post type that doesn't support author and verify `author:` is absent.
- [ ] Hit a post whose modified date equals its publish date and verify `last_modified:` is absent.
- [ ] Add a custom filter that injects nested arrays and verify the YAML is parseable by a real YAML parser.
- [ ] Add a custom filter that returns an unsupported value (e.g., `stdClass`) and verify the notice fires and the field is dropped without breaking the rest of the block.
- [ ] Add a custom filter that returns an empty array and verify no frontmatter block is emitted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)